### PR TITLE
Fixing 5XX logs not getting send in discord

### DIFF
--- a/src/app/app.go
+++ b/src/app/app.go
@@ -18,12 +18,14 @@ import (
 func Init() *gin.Engine {
 
 	router := gin.New()
-	router.Use(gin.Recovery())
 
 	//Set Logger
 	logger := lib.CreateGinLogger(os.Stdout, lib.LOGGER_TEXT_FORMATTER)
 	logger.AddHook(lib.CreateLogrusDiscordHook(config.Config.Logger.Discord["shin_channel"]))
 	router.Use(views.GinLoggerMiddleware(logger))
+
+	//Gin Recovery
+	router.Use(gin.Recovery())
 
 	router.Use(func(c *gin.Context) {
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 2*time.Second)

--- a/src/lib/log.go
+++ b/src/lib/log.go
@@ -95,14 +95,14 @@ func (ginLogger *GinLogger) Auto(id string, fields GinLogFields) {
 	reqLog := fmt.Sprintf("Request | %s | %s | %s | %s | %s", id, fields.Method, fields.Path, fields.RequestHeaders, fields.RequestBody.String())
 	resLog := fmt.Sprintf("Response | %s | %s | %s | %s | %d | %s | %s", id, fields.Method, fields.Path, fields.Headers, fields.StatusCode, fields.Body.String(), fields.Duration)
 
-	ginLogger.Info(reqLog)
-	if fields.StatusCode >= 100 {
+	if fields.StatusCode < 400 {
+		ginLogger.Info(reqLog)
 		ginLogger.Info(resLog)
-	}
-	if fields.StatusCode >= 400 {
+	} else if fields.StatusCode < 500 {
+		ginLogger.Warn(reqLog)
 		ginLogger.Warn(resLog)
-	}
-	if fields.StatusCode >= 500 {
+	} else {
+		ginLogger.Error(reqLog)
 		ginLogger.Error(resLog)
 	}
 }


### PR DESCRIPTION
fix: Moving Recovery after log middleware to collect panics
fix: Adding Request Logs on any levels customized
fix: Making boundaries more strict