### PR TITLE
TAS-2521: kyb verification must be unique on each org (+ other KYB issues)

### DIFF
--- a/src/app/models/kyb.go
+++ b/src/app/models/kyb.go
@@ -77,8 +77,18 @@ func (k *KYBVerification) Create(ctx context.Context, documents []string) (*KYBV
 }
 
 func (k *KYBVerification) ChangeStatus(ctx context.Context, status KybVerificationStatusType) error {
-	_, err := database.Query(ctx, "kyb/change_status", k.ID, status)
-	return err
+	rows, err := database.Query(ctx, "kyb/change_status", k.ID, status)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		if err := k.Scan(rows); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func GetById(id uuid.UUID) (*KYBVerification, error) {

--- a/src/app/views/kyb.go
+++ b/src/app/views/kyb.go
@@ -148,23 +148,25 @@ func kybVerificationGroup(router *gin.Engine) {
 			return
 		}
 
-		c.JSON(http.StatusOK, gin.H{})
+		c.JSON(http.StatusOK, verification)
 	})
 
 	g.GET("/:id/reject", adminAccessRequired(), func(c *gin.Context) {
 		ctx, _ := c.Get("ctx")
 		verificationId := c.Param("id")
 
-		kybVerification := models.KYBVerification{
-			ID: uuid.MustParse(verificationId),
-		}
-
-		if err := kybVerification.ChangeStatus(ctx.(context.Context), models.KYBStatusRejected); err != nil {
+		verification, err := models.GetById(uuid.MustParse(verificationId))
+		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
 
-		c.JSON(http.StatusOK, gin.H{})
+		if err := verification.ChangeStatus(ctx.(context.Context), models.KYBStatusRejected); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		c.JSON(http.StatusOK, verification)
 	})
 
 }

--- a/src/app/views/kyb.go
+++ b/src/app/views/kyb.go
@@ -148,7 +148,7 @@ func kybVerificationGroup(router *gin.Engine) {
 			return
 		}
 
-		c.JSON(http.StatusOK, verification)
+		c.JSON(http.StatusOK, gin.H{"message": "success"})
 	})
 
 	g.GET("/:id/reject", adminAccessRequired(), func(c *gin.Context) {

--- a/src/app/views/kyb.go
+++ b/src/app/views/kyb.go
@@ -166,7 +166,7 @@ func kybVerificationGroup(router *gin.Engine) {
 			return
 		}
 
-		c.JSON(http.StatusOK, verification)
+		c.JSON(http.StatusOK, gin.H{"message": "success"})
 	})
 
 }

--- a/src/app/views/kyb.go
+++ b/src/app/views/kyb.go
@@ -24,8 +24,19 @@ func createDiscordReviewMessage(kyb *models.KYBVerification, u *models.User, org
 	message := fmt.Sprintf("ID: %s\n", kyb.ID)
 	message += "\nUser--------------------------------\n"
 	message += fmt.Sprintf("ID: %s\n", u.ID)
-	message += fmt.Sprintf("Firstname: %s\n", *u.FirstName)
-	message += fmt.Sprintf("Lastname: %s\n", *u.LastName)
+
+	if u.FirstName != nil {
+		message += fmt.Sprintf("Firstname: %s\n", *u.FirstName)
+	} else {
+		message += "Firstname: N/A\n"
+	}
+
+	if u.LastName != nil {
+		message += fmt.Sprintf("Lastname: %s\n", *u.LastName)
+	} else {
+		message += "Lastname: N/A\n"
+	}
+
 	message += fmt.Sprintf("Email: %s\n", u.Email)
 	message += "\nOrganization------------------------\n"
 	message += fmt.Sprintf("ID: %s\n", org.ID)

--- a/src/sql/migrations/20241014154007_kyb-unique-org.up.sql
+++ b/src/sql/migrations/20241014154007_kyb-unique-org.up.sql
@@ -1,0 +1,10 @@
+-- Delete the least recent KYBs and remain one last recent one per organization (newest remains)
+DELETE FROM kyb_verifications
+WHERE (organization_id, created_at) NOT IN (
+    SELECT organization_id, MAX(created_at)
+    FROM kyb_verifications
+    GROUP BY organization_id
+);
+
+-- Making organization_id unique among KYB columns
+ALTER TABLE kyb_verifications ADD CONSTRAINT kyb_verifications_unique_organization_id UNIQUE (organization_id);


### PR DESCRIPTION
Fixing Bug: kyb verification must be unique on each org
Fixing Bug: Fixing KYB responses
Fixing Bug: Unifying KYB responses
Fixing Bug: Making organization id unique
Fixing Bug: FIxing issue where if user doesn't have name or last name system panics

@jeyem
# ⚠️  Please Note: Check [this query](https://github.com/socious-io/shin-api/blob/6fe1fef3e3f64c1986cb8c7199cedccd0a3a4cda/src/sql/migrations/20241014154007_kyb-unique-org.up.sql), I am deleting the least recent KYBs (except the last one per org) to be able to put organization_id unique constraint